### PR TITLE
Fix param converter

### DIFF
--- a/src/AdminPanel/Symfony/AdminBundle/Request/ParamConverter/AdminElementParamConverter.php
+++ b/src/AdminPanel/Symfony/AdminBundle/Request/ParamConverter/AdminElementParamConverter.php
@@ -55,6 +55,10 @@ class AdminElementParamConverter implements ParamConverterInterface
             return false;
         }
 
+        if (!$configuration->getClass()) {
+            return false;
+        }
+
         if (!class_exists($configuration->getClass()) && !interface_exists($configuration->getClass())) {
             return false;
         }

--- a/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/AppKernel.php
+++ b/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/AppKernel.php
@@ -61,7 +61,7 @@ class AppKernel extends Kernel
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         $routes->mount('/', $routes->import('@AdminPanelBundle/Resources/config/routing/admin.yml'));
-        $routes->add('/custom-action', 'kernel:customAction', 'custom_action');
+        $routes->add('/custom-action/{id}', 'kernel:customAction', 'custom_action');
     }
 
     /**
@@ -126,6 +126,11 @@ class AppKernel extends Kernel
                         'prefix' => 'AdminPanel\Symfony\AdminBundle\Tests\Functional\Entity'
                     ]
                 ]
+            ]
+        ]);
+        $c->loadFromExtension('sensio_framework_extra', [
+            'request' => [
+                'converters' => true
             ]
         ]);
 

--- a/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/ListPageTest.php
+++ b/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/ListPageTest.php
@@ -30,7 +30,7 @@ class ListPageTest extends FunctionalTestCase
         (new ListPage($this->client))
             ->open()
             ->clickCustomButtonForElementWithNumber(1)
-            ->shouldBeRedirectedTo('/custom-action?id={id}')
+            ->shouldBeRedirectedTo('/custom-action/{id}')
         ;
     }
 

--- a/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/Page/CustomActionPage.php
+++ b/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/Page/CustomActionPage.php
@@ -11,6 +11,6 @@ class CustomActionPage extends BasePage
      */
     public function getUrl() : string
     {
-        return '/custom-action?id={id}';
+        return '/custom-action/{id}';
     }
 }


### PR DESCRIPTION
Admin Element Param Converter should not be called when class is not defined in config.