### PR TITLE
Dbal doctrine driver does not count correctly when group by was used

### DIFF
--- a/src/AdminPanel/Component/DataSource/Driver/Doctrine/DBAL/DoctrineDriver.php
+++ b/src/AdminPanel/Component/DataSource/Driver/Doctrine/DBAL/DoctrineDriver.php
@@ -75,7 +75,7 @@ final class DoctrineDriver extends DriverAbstract
 
         $countQueryBuilder = clone $this->currentQueryBuilder;
 
-        $countQueryBuilder->select(sprintf('COUNT(%s)', $this->countField));
+        $countQueryBuilder->select(sprintf('%s', $this->countField));
         $countQueryBuilder->resetQueryPart('orderBy');
 
         if ($max > 0) {
@@ -89,7 +89,7 @@ final class DoctrineDriver extends DriverAbstract
             $indexedResults[$sigleRow[$this->indexBy]] = $sigleRow;
         }
 
-        $count = $connection->fetchColumn($countQueryBuilder->getSQL(), $this->currentQueryBuilder->getParameters());
+        $count = count($connection->executeQuery($countQueryBuilder->getSQL(), $this->currentQueryBuilder->getParameters())->fetchAll());
 
         return new Result($indexedResults, $count);
     }

--- a/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/Element/DbalUserElement.php
+++ b/tests/AdminPanel/Symfony/AdminBundle/Tests/Functional/Element/DbalUserElement.php
@@ -89,7 +89,8 @@ final class DbalUserElement extends GenericListBatchDeleteElement
         $queryBuilder
             ->select('u.id, u.username, u.hasNewsletter, u.hasSomethingElse, u.credits, u.createdAt')
             ->from('admin_panel_users', 'u')
-            ->orderBy('u.createdAt', 'DESC');
+            ->orderBy('u.createdAt', 'DESC')
+            ->groupBy('u.id');
 
         $datasource = $factory->createDataSource('doctrine-dbal', [
             'queryBuilder' => $queryBuilder,


### PR DESCRIPTION
**DESCRIPTION:**

There is an issue with `GROUP BY` statement. When `GROUP BY` is used by user on the same column which `$countQueryBuilder` uses, the result is incorrect (mostly we end up with `1`) and paginator stops working properly.

**REMARKS:**

I could not use simple `rowCount()` method according to documentation, which says:
```
this behavior is not guaranteed for all databases and should not be relied on
```
If someone knows more efficient solution, please let me know.